### PR TITLE
Fix 'No active player' bug

### DIFF
--- a/hypr/scripts/track-time.fish
+++ b/hypr/scripts/track-time.fish
@@ -7,4 +7,4 @@ end
 set -l position (caelestia shell mpris getActive position)
 set -l length (caelestia shell mpris getActive length)
 
-test $position != 'No media' && echo "$(fmt-time $position)/$(fmt-time $length)"
+test $position != 'No media' -a $position != 'No active player' && echo "$(fmt-time $position)/$(fmt-time $length)"


### PR DESCRIPTION
## Prevent hyprlock errors when no media is playing

### Problem

When there is no active player or nothing playing, `hyprlock` errors out due to invalid input passed to the `math` command in `track-time.fish`. This results in repeated error messages like:

```
math: Error: Unknown function
'No active player / 60 % 60'
```

### Solution

This PR updates the script to check if `$position` is neither `"No media"` nor `"No active player"` before calling `fmt-time`. This prevents invalid strings from being passed to `math`, eliminating the errors in `hyprlock` when nothing is playing.
