### PR TITLE
fix: keybind for previous song

### DIFF
--- a/hypr/hyprland/keybinds.conf
+++ b/hypr/hyprland/keybinds.conf
@@ -25,8 +25,8 @@ bindl = , XF86AudioPlay, global, caelestia:mediaToggle
 bindl = , XF86AudioPause, global, caelestia:mediaToggle
 bindl = Ctrl+Super, Equal, global, caelestia:mediaNext
 bindl = , XF86AudioNext, global, caelestia:mediaNext
-bindl = Ctrl+Super, Minus, global, caelestia:mediaPrevious
-bindl = , XF86AudioPrev, global, caelestia:mediaPrevious
+bindl = Ctrl+Super, Minus, global, caelestia:mediaPrev
+bindl = , XF86AudioPrev, global, caelestia:mediaPrev
 bindl = , XF86AudioStop, global, caelestia:mediaStop
 
 bindr = Ctrl+Super+Shift, R, exec, qs -c caelestia kill


### PR DESCRIPTION
Use `caelestia:mediaPrev` instead of `caelestia:mediaPrevious` in `hypr/hyprland/keybinds.conf`