### PR TITLE
FIX : Hide Specific UI Elements for Spicetify

### DIFF
--- a/spicetify/Themes/caelestia/user.css
+++ b/spicetify/Themes/caelestia/user.css
@@ -27,3 +27,24 @@ button,
 #recent-searches-dropdown > div {
     background-color: var(--spice-main-elevated) !important;
 }
+
+/* Hide the main header on the home page */
+.main-home-homeHeader {
+  display: none !important;
+}
+
+/* Remove any decorative pseudo-elements inside the home header */
+.search-searchCategory-contentArea::before,
+.search-searchCategory-contentArea::after {
+  display: none !important;
+  content: none !important;
+}
+
+/* Hide the gradient background bar that appears between the playlist/album header and the song list */
+.main-actionBarBackground-background {
+  display: none !important;
+}
+
+.main-view-container__scroll-node-child div[style*="--background-base"]:not([style*="--background-base-min-contrast"]) {
+  display: none !important;
+}


### PR DESCRIPTION
## Description

This PR improves the **Caelestia (Light UI)** for Spicetify by addressing layout and visibility issues caused by dark UI elements. In light mode, components like the black home headers and gradient background bars appeared visually inconsistent—overlaying dark shades on a white interface.

To resolve this, I had to hide several non-essential visual elements.

---

## Changes Summary

- **Removed Home Page Header**  
  Hides `.main-home-homeHeader` to reduce top-of-page clutter and dark contrast.

- **Removed Pseudo-Elements from Search UI**  
  Hides `::before` and `::after` on `.search-searchCategory-contentArea` to eliminate extra styling.

- **Removed Gradient Action Bar Background**  
  Hides `.main-actionBarBackground-background` to clean up the song list section under playlist/album headers.

- **Removed Inline-Styled Background Elements**  
  Targets elements within `.main-view-container__scroll-node-child` that have `--background-base` (but not `--background-base-min-contrast`) in their inline styles, removing conflicting colored blocks.

---

## Before Changes

![Before Example 1](https://github.com/user-attachments/assets/812a24cf-01eb-4ec4-86d3-787402b7d65e)  
![Before Example 2](https://github.com/user-attachments/assets/d0d5b97b-a74d-4254-bd95-80b9da5b156c)

---

## After Changes

![After Example 1](https://github.com/user-attachments/assets/ffa232b8-1364-4d6e-a5ff-25dd8e2ea104)  
![After Example 2](https://github.com/user-attachments/assets/2ca9fc42-a718-4e7a-b5ae-22d1ff2892a8)