### PR TITLE
Fix native messaging path for theme sync

### DIFF
--- a/install.fish
+++ b/install.fish
@@ -257,7 +257,7 @@ if set -q _flag_zen
     end
 
     # Install native app
-    set -l hosts $HOME/.zen/native-messaging-hosts
+    set -l hosts $HOME/.mozilla/native-messaging-hosts
     set -l lib $HOME/.local/lib/caelestia
 
     if confirm-overwrite $hosts/caelestiafox.json


### PR DESCRIPTION
The `native-messaging-hosts` directory was previously placed under `.zen`, which prevents the native messaging from working properly.

This fix moves it to the correct location: `.mozilla/native-messaging-hosts`, allowing the extension to sync system theme settings as expected.