### PR TITLE
hyprland: fix script shebang

### DIFF
--- a/hypr/scripts/get-overrides.fish
+++ b/hypr/scripts/get-overrides.fish
@@ -1,4 +1,4 @@
-#!/bin/fish
+#!/usr/bin/env fish
 
 set -l src (dirname (status filename))
 set -q XDG_CONFIG_HOME && set -l config $XDG_CONFIG_HOME/caelestia || set -l config $HOME/.config/caelestia

--- a/hypr/scripts/monitor-config.fish
+++ b/hypr/scripts/monitor-config.fish
@@ -1,4 +1,4 @@
-#!/bin/fish
+#!/usr/bin/env fish
 
 set -q XDG_CONFIG_HOME && set -l config $XDG_CONFIG_HOME || set -l config $HOME/.config
 set -l config_path $config/caelestia/hypr.json


### PR DESCRIPTION
Fixed shebang line for hyprland scripts.
This is necessary to run on nixos.