### PR TITLE
feat: implement --codeready for modular development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@ The install script has some options for installing configs for some apps.
 
 ```
 $ ./install.fish -h
-usage: ./install.sh [-h] [--noconfirm] [--spotify] [--vscode] [--discord] [--paru]
+usage: ./install.sh [-h] [--noconfirm] [--spotify] [--vscode] [--codeready] [--discord] [--zen] [--paru]
 
 options:
   -h, --help                  show this help message and exit
   --noconfirm                 do not confirm package installation
   --spotify                   install Spotify (Spicetify)
   --vscode=[codium|code]      install VSCodium (or VSCode)
+  --codeready[=groups]        install development tools
+                              groups: python,java,nodejs,tools (comma-separated)
+                              default: all groups if no value specified
+                              example: --codeready=python,java
   --discord                   install Discord (OpenAsar + Equicord)
   --zen                       install Zen browser
   --paru                      use paru instead of yay as AUR helper


### PR DESCRIPTION
## Add `--codeready` option for modular development environment setup

### Description

This PR adds a new `--codeready` flag to the installer that enables selective installation of development tools with automatic VSCode/Codium integration. Perfect for developers who want a clean, modular setup without bloated IDEs.

### Features

#### Selective Group Installation
- **Python ecosystem**: `python`, `pip`, `virtualenv`, `poetry`
- **Java ecosystem**: `jdk-openjdk`, `openjdk-doc`, `maven`, `gradle`
- **Node.js ecosystem**: `nodejs`, `npm`, `nvm`
- **Essential tools**: `git`, `curl`, `wget`, `tree`

#### Usage Examples
```bash
# Install all development tools (default)
./install.fish --codeready

# Install specific groups only
./install.fish --codeready=python,java
./install.fish --codeready=nodejs,tools
./install.fish --codeready=python