### PR TITLE
hypr: update music rule to include Cider

### DIFF
--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -34,7 +34,7 @@ windowrule = center 1, class:nwg-look
 
 # Special workspaces
 windowrule = workspace special:sysmon, class:btop
-windowrule = workspace special:music, class:feishin|Spotify|Supersonic
+windowrule = workspace special:music, class:feishin|Spotify|Supersonic|Cider
 windowrule = workspace special:music, initialTitle:Spotify( Free)?  # Spotify wayland, it has no class for some reason
 windowrule = workspace special:communication, class:discord|equibop|vesktop|whatsapp
 windowrule = workspace special:todo, class:Todoist


### PR DESCRIPTION
This PR changes the windowrule for music workspace to include the [Cider (Apple Music) player](https://v2.cider.sh)