### PR TITLE
fix: use grim for full screenshots to ensure .png extension

### DIFF
--- a/hypr/hyprland/keybinds.conf
+++ b/hypr/hyprland/keybinds.conf
@@ -163,7 +163,8 @@ bind = Ctrl+Alt, Escape, exec, app2unit -- qps
 bind = Ctrl+Alt, V, exec, app2unit -- pavucontrol
 
 # Utilities
-bindl = , Print, exec, caelestia screenshot  # Full screen capture > clipboard
+#bindl = , Print, exec, caelestia screenshot  # Full screen capture > clipboard
+bindl = , Print, exec, grim ~/.cache/caelestia/screenshots/$(date +'%Y-%m-%d_%H-%M-%S').png && notify-send "Screenshot Captured" "Saved to ~/screenshots" -i camera-photo
 bind = Super+Shift, S, global, caelestia:screenshotFreeze  # Capture region (freeze)
 bind = Super+Shift+Alt, S, global, caelestia:screenshot  # Capture region
 bind = Super+Alt, R, exec, caelestia record -s  # Record screen with sound


### PR DESCRIPTION
Replaces the custom caelestia screenshot command with grim for full-screen captures.

Changes:
Fixes File Extensions: Ensures full screenshots are saved with a .png extension.