### PR TITLE
feat(hypr): add OCR screen text capture (Super+Shift+T)

### DIFF
--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -163,6 +163,7 @@ create_bind(vars.kbRecord, hl.dsp.exec_cmd("caelestia record"))
 create_bind(vars.kbRecordSound, hl.dsp.exec_cmd("caelestia record -s"))
 create_bind(vars.kbRecordRegion, hl.dsp.exec_cmd("caelestia record -r"))
 create_bind(vars.kbColorPicker, hl.dsp.exec_cmd("hyprpicker -a"))
+create_bind("SUPER + SHIFT + T", hl.dsp.exec_cmd("~/.config/hypr/scripts/ocr.fish " .. vars.ocrLang))
 
 -- Brightness
 create_bind("XF86MonBrightnessUp", hl.dsp.global("caelestia:brightnessUp"), locked)

--- a/hypr/scripts/ocr.fish
+++ b/hypr/scripts/ocr.fish
@@ -1,0 +1,21 @@
+#!/usr/bin/env fish
+
+set -qx WAYLAND_DISPLAY; or set -x WAYLAND_DISPLAY wayland-0
+set -x OMP_THREAD_LIMIT 1
+
+set lang (test (count $argv) -ge 1; and echo $argv[1]; or echo eng)
+
+set area (slurp -b '#00000088' -c '#ffffffaa' -w 1); or exit 1
+
+set tmp (mktemp /tmp/ocr-XXXXXX.txt)
+grim -g $area - | magick - -colorspace gray -resize 150% -contrast-stretch 0 - \
+    | tesseract -l $lang - - --psm 6 2>/dev/null > $tmp
+
+if test -s $tmp
+    cat $tmp | awk -v RS= -v ORS='\n\n' '{$1=$1}1' | wl-copy
+    notify-send -t 1500 -a OCR "Copied" "Text recognised and copied to clipboard"
+else
+    notify-send -t 2000 -u critical -a OCR "Error" "Failed to recognise text"
+end
+
+rm -f $tmp

--- a/hypr/variables.lua
+++ b/hypr/variables.lua
@@ -53,6 +53,7 @@ return {
     cursorTheme                = "sweet-cursors",
     cursorSize                 = 24,
     sleepGestureCmd            = "systemctl suspend-then-hibernate",
+    ocrLang                    = "eng", -- tesseract language(s); override in user config (e.g. "eng+rus")
 
     ------------------
     ---- KEYBINDS ----


### PR DESCRIPTION
## What

Adds a Wayland-native screen OCR workflow. Select a region with the cursor, the text gets recognised and copied to the clipboard.

Keybind: `Super+Shift+T`

## How it works

1. `slurp` prompts for a region selection
2. `grim` captures that region to stdout
3. ImageMagick converts to grayscale, scales up 150%, and normalises contrast — improves recognition accuracy on low-DPI screens and small fonts
4. `tesseract` runs OCR (`--psm 6`, uniform block mode) and writes the result to a temp file
5. `awk` collapses broken lines back into paragraphs
6. `wl-copy` puts the cleaned text on the clipboard
7. A `notify-send` notification confirms success or reports failure

## Configuration

The OCR language defaults to `eng`. To add more languages (e.g. Russian), install the corresponding tesseract data package and override the variable in `~/.config/caelestia/hypr-vars.conf`:

```
$ocrLang = eng+rus
```

## Dependencies added (optional)

- `tesseract` — OCR engine
- `tesseract-data-eng` — English language data
- `imagemagick` — image preprocessing

`grim`, `slurp`, and `wl-clipboard` are already required by the dots.

## Testing

Tested on Hyprland with a mixed eng/rus screen. Recognised both printed text and terminal output correctly.