### PR TITLE
feat(btop): show GPU pane by default

### DIFF
--- a/btop/btop.conf
+++ b/btop/btop.conf
@@ -61,7 +61,7 @@ graph_symbol_net = "default"
 graph_symbol_proc = "default"
 
 #* Manually set which boxes to show. Available values are "cpu mem net proc" and "gpu0" through "gpu5", separate values with whitespace.
-shown_boxes = "cpu mem net proc"
+shown_boxes = "cpu mem net proc gpu0"
 
 #* Update time in milliseconds, recommended 2000 ms or above for better sample times for graphs.
 update_ms = 2000


### PR DESCRIPTION
## Summary

Adds `gpu0` to the current layout, giving GPUs a dedicated panel instead of relying only on the compact GPU information in the CPU panel.

When a configured GPU index is unavailable, btop does not display an empty panel.

## Testing

- Confirmed `gpu0` displays a dedicated panel.
- Confirmed unavailable `gpu1` does not display empty panel.

## Side effects

The dedicated GPU panel uses additional screen space. It can still be toggled from within btop.

## Screenshot

<img width="2560" height="1440" alt="screenshot-20260728-104840" src="https://github.com/user-attachments/assets/afc90db5-7833-4945-ba3a-a806796a2c86" />