### PR TITLE
fix(manifest): create Caelestia config dir before Hyprland reload 

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,6 +5,9 @@ post_install = [
 ]
 post_update = ["caelestia shell -k; sleep 1; caelestia shell -d >/dev/null"]
 
+[packages_by_distro]
+cachyos = ["mainstream-quickshell-git"]
+
 # --- Core components ---
 
 [[components]]

--- a/manifest.toml
+++ b/manifest.toml
@@ -16,7 +16,7 @@ packages = [
     "xdg-desktop-portal-gtk",
     "ttf-jetbrains-mono-nerd",
 ]
-post_install = ["hyprctl reload >/dev/null"]
+post_install = ["mkdir -p ${XDG_CONFIG_HOME:-$HOME/.config}/caelestia", "hyprctl reload >/dev/null"]
 post_update = ["hyprctl reload >/dev/null"]
 [[components.entries]]
 src = "hypr"


### PR DESCRIPTION
## fix: create Caelestia config dir before Hyprland reload

On fresh installations, Hyprland could be reloaded before the `~/.config/caelestia` directory had been created.

This prevented the `hypr-vars.lua` file from being created and caused Hyprland to enter emergency mode due to a Lua import error:
<img width="1532" height="136" alt="pasted file" src="https://github.com/user-attachments/assets/f1caf47f-ed05-46a6-b614-ec46991df79f" />
(SS from CachyOS)

This change ensures that the Caelestia configuration directory exists before Hyprland is reloaded.

## fix: install mainstream Quickshell on CachyOS

Use `mainstream-quickshell-git` on CachyOS through the new `packages_by_distro` manifest support.

noctalia-qs provides quickshell-git, but its Quickshell build is not compatible with the APIs Caelestia Shell expects.

This change ensures that CachyOS installs the compatible upstream Quickshell provider without affecting other distributions.

## Note

The first commit (**create Caelestia config dir before Hyprland reload**) can be merged independently. (This fix has also been tested on its own)

The second commit (**install mainstream Quickshell on CachyOS**) depends on https://github.com/caelestia-dots/cli/pull/152

## Testing

**Tested on 3 fresh installations**

- EndeavourOS
- Garuda Linux
- CachyOS

<img width="605" height="480" alt="image" src="https://github.com/user-attachments/assets/34f43700-a5a0-45b9-b522-1495f51cfde3" />
<img width="605" height="480" alt="image" src="https://github.com/user-attachments/assets/026934d2-5350-4d1d-ae5f-831883588e4b" />
<img width="605" height="480" alt="image" src="https://github.com/user-attachments/assets/57d3d348-61f9-4e24-9ad3-eca94b305a61" />

The `mainstream-quickshell-git` fix is applied on CachyOS, while the other tested Arch-based distributions are not affected.

This test was run along with the changes I made in the CLI. You can check [here](https://github.com/caelestia-dots/cli/pull/152) for the change in the CLI.