### PR TITLE
feat(hypr): update keybinds.lua with every keybind's category and descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ You can find more information on configuring the shell and the CLI in their resp
 | `Super + L`           | Lock screen               |
 | `Super + Alt + L`     | Restore shell lockscreen  |
 | `Super + Shift + L`   | Run sleep command         |
-| `Super + Slash`           | Open keybind cheatsheet   |
+| `Super + Slash`       | Open keybind cheatsheet   |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ You can find more information on configuring the shell and the CLI in their resp
 | `Super + L`           | Lock screen               |
 | `Super + Alt + L`     | Restore shell lockscreen  |
 | `Super + Shift + L`   | Run sleep command         |
+| `Super + /`           | Open keybind cheatsheet   |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ You can find more information on configuring the shell and the CLI in their resp
 | `Super + L`           | Lock screen               |
 | `Super + Alt + L`     | Restore shell lockscreen  |
 | `Super + Shift + L`   | Run sleep command         |
-| `Super + /`           | Open keybind cheatsheet   |
+| `Super + Slash`           | Open keybind cheatsheet   |
 
 ---
 

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -75,7 +75,7 @@ create_bind(
     function(key)
         return normalise_keybind(key) == launcher_default and release or nil
     end,
-    "Launcher: Open the application launcher"
+    "Shell: Open the launcher"
 )
 
 -- Misc

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -190,12 +190,12 @@ create_bind(vars.kbFileExplorer, hl.dsp.exec_cmd(vars.fileExplorer), "Apps: Open
 create_bind(vars.kbAudioSettings, hl.dsp.exec_cmd(vars.audioSettings), "Apps: Open the audio settings")
 
 -- Utilities
-create_bind(vars.kbScreenshot, hl.dsp.exec_cmd("caelestia screenshot"), locked, "Utilities: Take a screenshot")
+create_bind(vars.kbScreenshot, hl.dsp.exec_cmd("caelestia screenshot"), "Utilities: Capture a screenshot", locked)
 create_bind(vars.kbScreenshotFreeze, hl.dsp.global("caelestia:screenshotFreeze"), "Utilities: Freeze the screen and capture a screenshot")
-create_bind(vars.kbScreenshotRegion, hl.dsp.global("caelestia:screenshot"), "Utilities: Capture a selected screen region")
-create_bind(vars.kbRecord, hl.dsp.exec_cmd("caelestia record"), "Utilities: Start screen recording")
-create_bind(vars.kbRecordSound, hl.dsp.exec_cmd("caelestia record -s"), "Utilities: Start screen recording with audio")
-create_bind(vars.kbRecordRegion, hl.dsp.exec_cmd("caelestia record -r"), "Utilities: Start recording a selected screen region")
+create_bind(vars.kbScreenshotRegion, hl.dsp.global("caelestia:screenshot"), "Utilities: Capture a screenshot of a selected region")
+create_bind(vars.kbRecord, hl.dsp.exec_cmd("caelestia record"), "Utilities: Start a screen recording")
+create_bind(vars.kbRecordSound, hl.dsp.exec_cmd("caelestia record -s"), "Utilities: Start a screen recording with audio")
+create_bind(vars.kbRecordRegion, hl.dsp.exec_cmd("caelestia record -r"), "Utilities: Start a screen recording of a selected region")
 create_bind(vars.kbColorPicker, hl.dsp.exec_cmd("hyprpicker -a"), "Utilities: Pick a color from the screen")
 
 -- Brightness

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -90,7 +90,7 @@ create_bind(vars.kbRestoreLock, function()
     hl.dispatch(hl.dsp.exec_cmd("caelestia shell -d"))
     hl.dispatch(hl.dsp.global("caelestia:lock"))
 end,
-    "Misc: Restore the shell and lock"
+    "Shell: Restore the shell and lock the screen"
 )
 
 -- Kill/restart

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -235,7 +235,7 @@ create_bind(vars.kbSleep, hl.dsp.exec_cmd(vars.sleepGestureCmd), "Misc: Run the 
 -- Clipboard and emoji picker
 create_bind(vars.kbClipboard, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard"), "Clipboard: Open clipboard history")
 create_bind(vars.kbClipboardDel, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard -d"), "Clipboard: Delete an item from clipboard history")
-create_bind(vars.kbEmoji, hl.dsp.exec_cmd("pkill fuzzel || caelestia emoji -p"), "Clipboard: Open the emoji picker")
+create_bind(vars.kbEmoji, hl.dsp.exec_cmd("pkill fuzzel || caelestia emoji -p"), "Utilities: Open the emoji picker")
 create_bind(
     vars.kbClipboardPasteLatest,
     hl.dsp.exec_cmd('sleep 0.5s && ydotool type -d 1 "$(cliphist list | head -1 | cliphist decode)"'),

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -35,13 +35,7 @@ local function flatten_keybinds(keybinds, keys)
     return keys
 end
 
-local function create_bind(keybinds, action, flags, description)
-    -- Shorthand: create_bind(keys, action, "description") with no special flags
-    if type(flags) == "string" and description == nil then
-        description = flags
-        flags = nil
-    end
-
+local function create_bind(keybinds, action, description, flags)
     local get_flags = type(flags) == "function" and flags or function()
         return flags
     end
@@ -72,10 +66,10 @@ local launcher_default = normalise_keybind("SUPER + SUPER_L")
 create_bind(
     vars.kbLauncher,
     hl.dsp.global("caelestia:launcher"),
+    "Shell: Open the launcher",
     function(key)
         return normalise_keybind(key) == launcher_default and release or nil
-    end,
-    "Shell: Open the launcher"
+    end
 )
 
 -- Misc
@@ -98,8 +92,8 @@ create_bind("CTRL + SUPER + SHIFT + R", hl.dsp.exec_cmd("qs -c caelestia kill"),
 create_bind(
     "CTRL + SUPER + ALT + R",
     hl.dsp.exec_cmd("qs -c caelestia kill; sleep .1; caelestia shell -d"),
-    release,
-    "Shell: Restart the shell"
+    "Shell: Restart the shell",
+    release
 )
 
 for i = 1, 10 do
@@ -111,26 +105,26 @@ for i = 1, 10 do
 end
 
 -- Go to workspace -1/+1
-create_bind(vars.kbPrevWs, hl.dsp.focus({ workspace = "-1" }), repeating_unless_mouse, "Workspace: Go to the previous workspace")
-create_bind(vars.kbNextWs, hl.dsp.focus({ workspace = "+1" }), repeating_unless_mouse, "Workspace: Go to the next workspace")
+create_bind(vars.kbPrevWs, hl.dsp.focus({ workspace = "-1" }), "Workspace: Go to the previous workspace", repeating_unless_mouse)
+create_bind(vars.kbNextWs, hl.dsp.focus({ workspace = "+1" }), "Workspace: Go to the next workspace", repeating_unless_mouse)
 
 -- Go to workspace group -1/+1
-create_bind(vars.kbPrevWsGroup, hl.dsp.focus({ workspace = "-10" }), repeating_unless_mouse, "Workspace: Go to the previous workspace group")
-create_bind(vars.kbNextWsGroup, hl.dsp.focus({ workspace = "+10" }), repeating_unless_mouse, "Workspace: Go to the next workspace group")
+create_bind(vars.kbPrevWsGroup, hl.dsp.focus({ workspace = "-10" }), "Workspace: Go to the previous workspace group", repeating_unless_mouse)
+create_bind(vars.kbNextWsGroup, hl.dsp.focus({ workspace = "+10" }), "Workspace: Go to the next workspace group", repeating_unless_mouse)
 
 -- Move window to workspace -1/+1
-create_bind(vars.kbMoveWinToWsNext, hl.dsp.window.move({ workspace = "+1" }), repeating_unless_mouse, "Workspace: Move the active window to the next workspace")
-create_bind(vars.kbMoveWinToWsPrev, hl.dsp.window.move({ workspace = "-1" }), repeating_unless_mouse, "Workspace: Move the active window to the previous workspace")
+create_bind(vars.kbMoveWinToWsNext, hl.dsp.window.move({ workspace = "+1" }), "Workspace: Move the active window to the next workspace", repeating_unless_mouse)
+create_bind(vars.kbMoveWinToWsPrev, hl.dsp.window.move({ workspace = "-1" }), "Workspace: Move the active window to the previous workspace", repeating_unless_mouse)
 
 -- Move window to/from special workspace
 create_bind(vars.kbMoveWinToWsSpecial, hl.dsp.window.move({ workspace = "special:special" }), "Workspace: Move the active window to the special workspace")
 create_bind(vars.kbMoveWinFromWsSpecial, hl.dsp.window.move({ workspace = "e+0" }), "Workspace: Move the active window out of the special workspace")
 
 -- Window groups
-create_bind(vars.kbWindowCycleNext, hl.dsp.window.cycle_next(), repeating, "Window Groups: Cycle to the next window")
-create_bind(vars.kbWindowCyclePrev, hl.dsp.window.cycle_next({ next = false }), repeating, "Window Groups: Cycle to the previous window")
-create_bind(vars.kbWindowGroupCycleNext, hl.dsp.group.next(), repeating, "Window Groups: Cycle to the next window group")
-create_bind(vars.kbWindowGroupCyclePrev, hl.dsp.group.prev(), repeating, "Window Groups: Cycle to the previous window group")
+create_bind(vars.kbWindowCycleNext, hl.dsp.window.cycle_next(), "Window Groups: Cycle to the next window", repeating)
+create_bind(vars.kbWindowCyclePrev, hl.dsp.window.cycle_next({ next = false }), "Window Groups: Cycle to the previous window", repeating)
+create_bind(vars.kbWindowGroupCycleNext, hl.dsp.group.next(), "Window Groups: Cycle to the next window group", repeating)
+create_bind(vars.kbWindowGroupCyclePrev, hl.dsp.group.prev(), "Window Groups: Cycle to the previous window group", repeating)
 create_bind(vars.kbToggleGroup, hl.dsp.group.toggle(), "Window Groups: Toggle the active window group")
 create_bind(vars.kbUngroup, hl.dsp.window.move({ out_of_group = true }), "Window Groups: Remove the active window from its group")
 create_bind(vars.kbGroupLockActive, hl.dsp.group.lock_active(), "Window Groups: Lock the active window group")
@@ -141,10 +135,10 @@ for _, dir in ipairs({ "left", "right", "up", "down" }) do
     create_bind("SUPER + SHIFT + " .. dir, hl.dsp.window.move({ direction = dir }), "Window Actions: Move the window to the " .. dir)
 end
 
-create_bind(vars.kbWindowDecreaseWidth, fn.resize_active_window(-10, 0), repeating, "Window Actions: Decrease the active window width")
-create_bind(vars.kbWindowIncreaseWidth, fn.resize_active_window(10, 0), repeating, "Window Actions: Increase the active window width")
-create_bind(vars.kbWindowDecreaseHeight, fn.resize_active_window(0, -10), repeating, "Window Actions: Decrease the active window height")
-create_bind(vars.kbWindowIncreaseHeight, fn.resize_active_window(0, 10), repeating, "Window Actions: Increase the active window height")
+create_bind(vars.kbWindowDecreaseWidth, fn.resize_active_window(-10, 0), "Window Actions: Decrease the active window width", repeating)
+create_bind(vars.kbWindowIncreaseWidth, fn.resize_active_window(10, 0), "Window Actions: Increase the active window width", repeating)
+create_bind(vars.kbWindowDecreaseHeight, fn.resize_active_window(0, -10), "Window Actions: Decrease the active window height", repeating)
+create_bind(vars.kbWindowIncreaseHeight, fn.resize_active_window(0, 10), "Window Actions: Increase the active window height", repeating)
 
 create_bind({ vars.kbMoveWindow, "SUPER + mouse:272" }, hl.dsp.window.drag(), "Window Actions: Move the window by dragging", mouse)
 create_bind({ vars.kbResizeWindow, "SUPER + mouse:273" }, hl.dsp.window.resize(), "Window Actions: Resize the window by dragging", mouse)
@@ -199,8 +193,8 @@ create_bind(vars.kbRecordRegion, hl.dsp.exec_cmd("caelestia record -r"), "Utilit
 create_bind(vars.kbColorPicker, hl.dsp.exec_cmd("hyprpicker -a"), "Utilities: Pick a color from the screen")
 
 -- Brightness
-create_bind("XF86MonBrightnessUp", hl.dsp.global("caelestia:brightnessUp"), locked, "Brightness: Increase screen brightness")
-create_bind("XF86MonBrightnessDown", hl.dsp.global("caelestia:brightnessDown"), locked, "Brightness: Decrease screen brightness")
+create_bind("XF86MonBrightnessUp", hl.dsp.global("caelestia:brightnessUp"), "Brightness: Increase screen brightness", locked)
+create_bind("XF86MonBrightnessDown", hl.dsp.global("caelestia:brightnessDown"), "Brightness: Decrease screen brightness", locked)
 
 -- Media
 create_bind({ vars.kbMediaToggle, "XF86AudioPlay", "XF86AudioPause" }, hl.dsp.global("caelestia:mediaToggle"), "Media: Toggle playback", locked)
@@ -209,24 +203,24 @@ create_bind({ vars.kbMediaPrev, "XF86AudioPrev" }, hl.dsp.global("caelestia:medi
 create_bind({ vars.kbMediaStop, "XF86AudioStop" }, hl.dsp.global("caelestia:mediaStop"), "Media: Stop playback", locked)
 
 -- Volume
-create_bind({ vars.kbVolumeMute, "XF86AudioMute" }, hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), locked, "Volume: Toggle system audio mute")
-create_bind("XF86AudioMicMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"), locked, "Volume: Toggle microphone mute")
+create_bind({ vars.kbVolumeMute, "XF86AudioMute" }, hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), "Volume: Toggle system audio mute", locked)
+create_bind("XF86AudioMicMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"), "Volume: Toggle microphone mute", locked)
 create_bind(
     "XF86AudioRaiseVolume",
     hl.dsp.exec_cmd(
         "wpctl set-mute @DEFAULT_AUDIO_SINK@ 0; wpctl set-volume -l " ..
         (vars.volumeMax / 100) .. " @DEFAULT_AUDIO_SINK@ " .. vars.volumeStep .. "%+"
     ),
-    locked_repeating,
-    "Volume: Increase system volume"
+    "Volume: Increase system volume",
+    locked_repeating
 )
 create_bind(
     "XF86AudioLowerVolume",
     hl.dsp.exec_cmd(
         "wpctl set-mute @DEFAULT_AUDIO_SINK@ 0; wpctl set-volume @DEFAULT_AUDIO_SINK@ " .. vars.volumeStep .. "%-"
     ),
-    locked_repeating,
-    "Volume: Decrease system volume"
+    "Volume: Decrease system volume",
+    locked_repeating
 )
 
 -- Sleep
@@ -239,8 +233,8 @@ create_bind(vars.kbEmoji, hl.dsp.exec_cmd("pkill fuzzel || caelestia emoji -p"),
 create_bind(
     vars.kbClipboardPasteLatest,
     hl.dsp.exec_cmd('sleep 0.5s && ydotool type -d 1 "$(cliphist list | head -1 | cliphist decode)"'),
-    locked,
-    "Clipboard: Paste the latest clipboard item"
+    "Clipboard: Paste the latest clipboard item",
+    locked
 )
 
 -- Testing

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -35,13 +35,31 @@ local function flatten_keybinds(keybinds, keys)
     return keys
 end
 
-local function create_bind(keybinds, action, flags)
+local function create_bind(keybinds, action, flags, description)
+    -- Shorthand: create_bind(keys, action, "description") with no special flags
+    if type(flags) == "string" and description == nil then
+        description = flags
+        flags = nil
+    end
+
     local get_flags = type(flags) == "function" and flags or function()
         return flags
     end
 
     for _, key in ipairs(flatten_keybinds(keybinds)) do
-        hl.bind(key, action, get_flags(key))
+        local base_flags = get_flags(key) or {}
+
+        -- Shallow copy so we never mutate a shared flags table (locked, mouse, etc.)
+        local bind_flags = {}
+        for k, v in pairs(base_flags) do
+            bind_flags[k] = v
+        end
+
+        if description then
+            bind_flags.description = description
+        end
+
+        hl.bind(key, action, bind_flags)
     end
 end
 
@@ -56,81 +74,87 @@ create_bind(
     hl.dsp.global("caelestia:launcher"),
     function(key)
         return normalise_keybind(key) == launcher_default and release or nil
-    end
+    end,
+    "Launcher: Open the application launcher"
 )
 
 -- Misc
-create_bind(vars.kbSession, hl.dsp.global("caelestia:session"))
-create_bind(vars.kbShowSidebar, hl.dsp.global("caelestia:sidebar"))
-create_bind(vars.kbClearNotifs, hl.dsp.global("caelestia:clearNotifs"), locked)
-create_bind(vars.kbShowPanels, hl.dsp.global("caelestia:showall"))
-create_bind(vars.kbLock, hl.dsp.global("caelestia:lock"))
+create_bind(vars.kbSession, hl.dsp.global("caelestia:session"), "Misc: Open the session controls")
+create_bind(vars.kbShowSidebar, hl.dsp.global("caelestia:sidebar"), "Misc: Show the sidebar")
+create_bind(vars.kbClearNotifs, hl.dsp.global("caelestia:clearNotifs"), locked, "Misc: Clear all notifications")
+create_bind(vars.kbShowPanels, hl.dsp.global("caelestia:showall"), "Misc: Show all panels")
+create_bind(vars.kbLock, hl.dsp.global("caelestia:lock"), "Misc: Lock the session")
 
 -- Restore lock
 create_bind(vars.kbRestoreLock, function()
     hl.dispatch(hl.dsp.exec_cmd("caelestia shell -d"))
     hl.dispatch(hl.dsp.global("caelestia:lock"))
-end)
+end,
+    "Misc: Restore the shell and lock"
+)
 
 -- Kill/restart
-create_bind("CTRL + SUPER + SHIFT + R", hl.dsp.exec_cmd("qs -c caelestia kill"), release)
+create_bind("CTRL + SUPER + SHIFT + R", hl.dsp.exec_cmd("qs -c caelestia kill"), release, "System: Restart the Caelestia shell")
 create_bind(
     "CTRL + SUPER + ALT + R",
     hl.dsp.exec_cmd("qs -c caelestia kill; sleep .1; caelestia shell -d"),
-    release
+    release,
+    "System: Restart the Caelestia shell and reload it cleanly"
 )
 
 for i = 1, 10 do
     local key = i % 10 -- 10 maps to key 0
-    create_bind(extend_keybind(vars.kbGoToWs, key), fn.wsaction("focus", "", i))
-    create_bind(extend_keybind(vars.kbMoveWinToWs, key), fn.wsaction("move", "", i))
-    create_bind(extend_keybind(vars.kbGoToWsGroup, key), fn.wsaction("focus", "group", i))
-    create_bind(extend_keybind(vars.kbMoveWinToWsGroup, key), fn.wsaction("move", "group", i))
+    create_bind(extend_keybind(vars.kbGoToWs, key), fn.wsaction("focus", "", i), "Workspace: Go to the selected workspace")
+    create_bind(extend_keybind(vars.kbMoveWinToWs, key), fn.wsaction("move", "", i), "Workspace: Move the active window to the selected workspace")
+    create_bind(extend_keybind(vars.kbGoToWsGroup, key), fn.wsaction("focus", "group", i), "Workspace: Go to the selected workspace group")
+    create_bind(extend_keybind(vars.kbMoveWinToWsGroup, key), fn.wsaction("move", "group", i), "Workspace: Move the active window to the selected workspace group")
 end
 
 -- Go to workspace -1/+1
-create_bind(vars.kbPrevWs, hl.dsp.focus({ workspace = "-1" }), repeating_unless_mouse)
-create_bind(vars.kbNextWs, hl.dsp.focus({ workspace = "+1" }), repeating_unless_mouse)
+create_bind(vars.kbPrevWs, hl.dsp.focus({ workspace = "-1" }), repeating_unless_mouse, "Workspace: Go to the previous workspace")
+create_bind(vars.kbNextWs, hl.dsp.focus({ workspace = "+1" }), repeating_unless_mouse, "Workspace: Go to the next workspace")
 
 -- Go to workspace group -1/+1
-create_bind(vars.kbPrevWsGroup, hl.dsp.focus({ workspace = "-10" }), repeating_unless_mouse)
-create_bind(vars.kbNextWsGroup, hl.dsp.focus({ workspace = "+10" }), repeating_unless_mouse)
+create_bind(vars.kbPrevWsGroup, hl.dsp.focus({ workspace = "-10" }), repeating_unless_mouse, "Workspace: Go to the previous workspace group")
+create_bind(vars.kbNextWsGroup, hl.dsp.focus({ workspace = "+10" }), repeating_unless_mouse, "Workspace: Go to the next workspace group")
 
 -- Move window to workspace -1/+1
-create_bind(vars.kbMoveWinToWsNext, hl.dsp.window.move({ workspace = "+1" }), repeating_unless_mouse)
-create_bind(vars.kbMoveWinToWsPrev, hl.dsp.window.move({ workspace = "-1" }), repeating_unless_mouse)
+create_bind(vars.kbMoveWinToWsNext, hl.dsp.window.move({ workspace = "+1" }), repeating_unless_mouse, "Workspace: Move the active window to the next workspace")
+create_bind(vars.kbMoveWinToWsPrev, hl.dsp.window.move({ workspace = "-1" }), repeating_unless_mouse, "Workspace: Move the active window to the previous workspace")
 
 -- Move window to/from special workspace
-create_bind(vars.kbMoveWinToWsSpecial, hl.dsp.window.move({ workspace = "special:special" }))
-create_bind(vars.kbMoveWinFromWsSpecial, hl.dsp.window.move({ workspace = "e+0" }))
+create_bind(vars.kbMoveWinToWsSpecial, hl.dsp.window.move({ workspace = "special:special" }), "Workspace: Move the active window to the special workspace")
+create_bind(vars.kbMoveWinFromWsSpecial, hl.dsp.window.move({ workspace = "e+0" }), "Workspace: Move the active window out of the special workspace")
 
 -- Window groups
-create_bind(vars.kbWindowCycleNext, hl.dsp.window.cycle_next(), repeating)
-create_bind(vars.kbWindowCyclePrev, hl.dsp.window.cycle_next({ next = false }), repeating)
-create_bind(vars.kbWindowGroupCycleNext, hl.dsp.group.next(), repeating)
-create_bind(vars.kbWindowGroupCyclePrev, hl.dsp.group.prev(), repeating)
-create_bind(vars.kbToggleGroup, hl.dsp.group.toggle())
-create_bind(vars.kbUngroup, hl.dsp.window.move({ out_of_group = true }))
-create_bind(vars.kbGroupLockActive, hl.dsp.group.lock_active())
+create_bind(vars.kbWindowCycleNext, hl.dsp.window.cycle_next(), repeating, "Window Groups: Cycle to the next window")
+create_bind(vars.kbWindowCyclePrev, hl.dsp.window.cycle_next({ next = false }), repeating, "Window Groups: Cycle to the previous window")
+create_bind(vars.kbWindowGroupCycleNext, hl.dsp.group.next(), repeating, "Window Groups: Cycle to the next window group")
+create_bind(vars.kbWindowGroupCyclePrev, hl.dsp.group.prev(), repeating, "Window Groups: Cycle to the previous window group")
+create_bind(vars.kbToggleGroup, hl.dsp.group.toggle(), "Window Groups: Toggle the active window group")
+create_bind(vars.kbUngroup, hl.dsp.window.move({ out_of_group = true }), "Window Groups: Remove the active window from its group")
+create_bind(vars.kbGroupLockActive, hl.dsp.group.lock_active(), "Window Groups: Lock the active window group")
 
 -- Window actions
 for _, dir in ipairs({ "left", "right", "up", "down" }) do
-    create_bind("SUPER + " .. dir, hl.dsp.focus({ direction = dir }))
-    create_bind("SUPER + SHIFT + " .. dir, hl.dsp.window.move({ direction = dir }))
+    create_bind("SUPER + " .. dir, hl.dsp.focus({ direction = dir }), "Window Actions: Focus the window in the specified direction")
+    create_bind("SUPER + SHIFT + " .. dir, hl.dsp.window.move({ direction = dir }), "Window Actions: Move the active window in the specified direction")
 end
 
-create_bind(vars.kbWindowDecreaseWidth, fn.resize_active_window(-10, 0), repeating)
-create_bind(vars.kbWindowIncreaseWidth, fn.resize_active_window(10, 0), repeating)
-create_bind(vars.kbWindowDecreaseHeight, fn.resize_active_window(0, -10), repeating)
-create_bind(vars.kbWindowIncreaseHeight, fn.resize_active_window(0, 10), repeating)
+create_bind(vars.kbWindowDecreaseWidth, fn.resize_active_window(-10, 0), repeating, "Window Actions: Decrease the active window width")
+create_bind(vars.kbWindowIncreaseWidth, fn.resize_active_window(10, 0), repeating, "Window Actions: Increase the active window width")
+create_bind(vars.kbWindowDecreaseHeight, fn.resize_active_window(0, -10), repeating, "Window Actions: Decrease the active window height")
+create_bind(vars.kbWindowIncreaseHeight, fn.resize_active_window(0, 10), repeating, "Window Actions: Increase the active window height")
 
-create_bind({ vars.kbMoveWindow, "SUPER + mouse:272" }, hl.dsp.window.drag(), mouse)
-create_bind({ vars.kbResizeWindow, "SUPER + mouse:273" }, hl.dsp.window.resize(), mouse)
-create_bind(vars.kbCenterWindow, hl.dsp.window.center())
+create_bind({ vars.kbMoveWindow, "SUPER + mouse:272" }, hl.dsp.window.drag(), mouse, "Window Actions: Drag the active window")
+create_bind({ vars.kbResizeWindow, "SUPER + mouse:273" }, hl.dsp.window.resize(), mouse, "Window Actions: Resize the active window")
+create_bind(vars.kbCenterWindow, hl.dsp.window.center(), "Window Actions: Center the active window")
 create_bind(vars.kbNormalizeWindow, function()
     hl.dispatch(hl.dsp.window.resize(fn.resize_by_screen(55, 70)))
     hl.dispatch(hl.dsp.window.center())
-end)
+end,
+    "Window Actions: Resize and center the active window"
+)
 create_bind(vars.kbWindowPip, function()
     local a = hl.get_active_window()
     if a then
@@ -142,76 +166,81 @@ create_bind(vars.kbWindowPip, function()
             hl.dispatch(x)
         end
     end
-end)
-create_bind(vars.kbPinWindow, hl.dsp.window.pin())
-create_bind(vars.kbWindowFullscreen, hl.dsp.window.fullscreen({ mode = "fullscreen" }))
-create_bind(vars.kbWindowBorderedFullscreen, hl.dsp.window.fullscreen({ mode = "maximized" }))
-create_bind(vars.kbToggleWindowFloating, hl.dsp.window.float())
-create_bind(vars.kbCloseWindow, hl.dsp.window.close())
+end,
+    "Window Actions: Toggle picture-in-picture mode"
+)
+create_bind(vars.kbPinWindow, hl.dsp.window.pin(), "Window Actions: Pin the active window")
+create_bind(vars.kbWindowFullscreen, hl.dsp.window.fullscreen({ mode = "fullscreen" }), "Window Actions: Toggle fullscreen mode")
+create_bind(vars.kbWindowBorderedFullscreen, hl.dsp.window.fullscreen({ mode = "maximized" }), "Window Actions: Toggle maximized mode")
+create_bind(vars.kbToggleWindowFloating, hl.dsp.window.float(), "Window Actions: Toggle floating mode")
+create_bind(vars.kbCloseWindow, hl.dsp.window.close(), "Window Actions: Close the active window")
 
 -- Special workspace toggles
-create_bind(vars.kbSpecialWs, fn.toggle("specialws"))
-create_bind(vars.kbSystemMonitorWs, fn.toggle("sysmon"))
-create_bind(vars.kbMusicWs, fn.toggle("music"))
-create_bind(vars.kbCommunicationWs, fn.toggle("communication"))
-create_bind(vars.kbTodoWs, fn.toggle("todo"))
+create_bind(vars.kbSpecialWs, fn.toggle("specialws"), "Special Workspaces: Toggle the special workspace")
+create_bind(vars.kbSystemMonitorWs, fn.toggle("sysmon"), "Special Workspaces: Toggle the system monitor workspace")
+create_bind(vars.kbMusicWs, fn.toggle("music"), "Special Workspaces: Toggle the music workspace")
+create_bind(vars.kbCommunicationWs, fn.toggle("communication"), "Special Workspaces: Toggle the communication workspace")
+create_bind(vars.kbTodoWs, fn.toggle("todo"), "Special Workspaces: Toggle the todo workspace")
 
 -- Apps
-create_bind(vars.kbTerminal, hl.dsp.exec_cmd(vars.terminal))
-create_bind(vars.kbBrowser, hl.dsp.exec_cmd(vars.browser))
-create_bind(vars.kbEditor, hl.dsp.exec_cmd(vars.editor))
-create_bind(vars.kbFileExplorer, hl.dsp.exec_cmd(vars.fileExplorer))
-create_bind(vars.kbAudioSettings, hl.dsp.exec_cmd(vars.audioSettings))
+create_bind(vars.kbTerminal, hl.dsp.exec_cmd(vars.terminal), "Apps: Open the terminal")
+create_bind(vars.kbBrowser, hl.dsp.exec_cmd(vars.browser), "Apps: Open the web browser")
+create_bind(vars.kbEditor, hl.dsp.exec_cmd(vars.editor), "Apps: Open the code editor")
+create_bind(vars.kbFileExplorer, hl.dsp.exec_cmd(vars.fileExplorer), "Apps: Open the file explorer")
+create_bind(vars.kbAudioSettings, hl.dsp.exec_cmd(vars.audioSettings), "Apps: Open the audio settings")
 
 -- Utilities
-create_bind(vars.kbScreenshot, hl.dsp.exec_cmd("caelestia screenshot"), locked)
-create_bind(vars.kbScreenshotFreeze, hl.dsp.global("caelestia:screenshotFreeze"))
-create_bind(vars.kbScreenshotRegion, hl.dsp.global("caelestia:screenshot"))
-create_bind(vars.kbRecord, hl.dsp.exec_cmd("caelestia record"))
-create_bind(vars.kbRecordSound, hl.dsp.exec_cmd("caelestia record -s"))
-create_bind(vars.kbRecordRegion, hl.dsp.exec_cmd("caelestia record -r"))
-create_bind(vars.kbColorPicker, hl.dsp.exec_cmd("hyprpicker -a"))
+create_bind(vars.kbScreenshot, hl.dsp.exec_cmd("caelestia screenshot"), locked, "Utilities: Take a screenshot")
+create_bind(vars.kbScreenshotFreeze, hl.dsp.global("caelestia:screenshotFreeze"), "Utilities: Freeze the screen and capture a screenshot")
+create_bind(vars.kbScreenshotRegion, hl.dsp.global("caelestia:screenshot"), "Utilities: Capture a selected screen region")
+create_bind(vars.kbRecord, hl.dsp.exec_cmd("caelestia record"), "Utilities: Start screen recording")
+create_bind(vars.kbRecordSound, hl.dsp.exec_cmd("caelestia record -s"), "Utilities: Start screen recording with audio")
+create_bind(vars.kbRecordRegion, hl.dsp.exec_cmd("caelestia record -r"), "Utilities: Start recording a selected screen region")
+create_bind(vars.kbColorPicker, hl.dsp.exec_cmd("hyprpicker -a"), "Utilities: Pick a color from the screen")
 
 -- Brightness
-create_bind("XF86MonBrightnessUp", hl.dsp.global("caelestia:brightnessUp"), locked)
-create_bind("XF86MonBrightnessDown", hl.dsp.global("caelestia:brightnessDown"), locked)
+create_bind("XF86MonBrightnessUp", hl.dsp.global("caelestia:brightnessUp"), locked, "Brightness: Increase screen brightness")
+create_bind("XF86MonBrightnessDown", hl.dsp.global("caelestia:brightnessDown"), locked, "Brightness: Decrease screen brightness")
 
 -- Media
-create_bind({ vars.kbMediaToggle, "XF86AudioPlay", "XF86AudioPause" }, hl.dsp.global("caelestia:mediaToggle"), locked)
-create_bind({ vars.kbMediaNext, "XF86AudioNext" }, hl.dsp.global("caelestia:mediaNext"), locked)
-create_bind({ vars.kbMediaPrev, "XF86AudioPrev" }, hl.dsp.global("caelestia:mediaPrev"), locked)
-create_bind({ vars.kbMediaStop, "XF86AudioStop" }, hl.dsp.global("caelestia:mediaStop"), locked)
+create_bind({ vars.kbMediaToggle, "XF86AudioPlay", "XF86AudioPause" }, hl.dsp.global("caelestia:mediaToggle"), locked, "Media: Play or pause media")
+create_bind({ vars.kbMediaNext, "XF86AudioNext" }, hl.dsp.global("caelestia:mediaNext"), locked, "Media: Skip to the next track")
+create_bind({ vars.kbMediaPrev, "XF86AudioPrev" }, hl.dsp.global("caelestia:mediaPrev"), locked, "Media: Go to the previous track")
+create_bind({ vars.kbMediaStop, "XF86AudioStop" }, hl.dsp.global("caelestia:mediaStop"), locked, "Media: Stop media playback")
 
 -- Volume
-create_bind({ vars.kbVolumeMute, "XF86AudioMute" }, hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), locked)
-create_bind("XF86AudioMicMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"), locked)
+create_bind({ vars.kbVolumeMute, "XF86AudioMute" }, hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), locked, "Volume: Toggle system audio mute")
+create_bind("XF86AudioMicMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"), locked, "Volume: Toggle microphone mute")
 create_bind(
     "XF86AudioRaiseVolume",
     hl.dsp.exec_cmd(
         "wpctl set-mute @DEFAULT_AUDIO_SINK@ 0; wpctl set-volume -l " ..
         (vars.volumeMax / 100) .. " @DEFAULT_AUDIO_SINK@ " .. vars.volumeStep .. "%+"
     ),
-    locked_repeating
+    locked_repeating,
+    "Volume: Increase system volume"
 )
 create_bind(
     "XF86AudioLowerVolume",
     hl.dsp.exec_cmd(
         "wpctl set-mute @DEFAULT_AUDIO_SINK@ 0; wpctl set-volume @DEFAULT_AUDIO_SINK@ " .. vars.volumeStep .. "%-"
     ),
-    locked_repeating
+    locked_repeating,
+    "Volume: Decrease system volume"
 )
 
 -- Sleep
-create_bind(vars.kbSleep, hl.dsp.exec_cmd(vars.sleepGestureCmd), locked)
+create_bind(vars.kbSleep, hl.dsp.exec_cmd(vars.sleepGestureCmd), locked, "Sleep: Suspend and hibernate the system")
 
 -- Clipboard and emoji picker
-create_bind(vars.kbClipboard, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard"))
-create_bind(vars.kbClipboardDel, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard -d"))
-create_bind(vars.kbEmoji, hl.dsp.exec_cmd("pkill fuzzel || caelestia emoji -p"))
+create_bind(vars.kbClipboard, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard"), "Clipboard: Open clipboard history")
+create_bind(vars.kbClipboardDel, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard -d"), "Clipboard: Delete an item from clipboard history")
+create_bind(vars.kbEmoji, hl.dsp.exec_cmd("pkill fuzzel || caelestia emoji -p"), "Clipboard: Open the emoji picker")
 create_bind(
     vars.kbClipboardPasteLatest,
     hl.dsp.exec_cmd('sleep 0.5s && ydotool type -d 1 "$(cliphist list | head -1 | cliphist decode)"'),
-    locked
+    locked,
+    "Clipboard: Paste the latest clipboard item"
 )
 
 -- Testing
@@ -222,4 +251,11 @@ create_bind(
         [["Here's a really long message to test truncation and wrapping\nYou can middle click or flick this notification to dismiss it!"]] ..
         " -a 'Shell' -A 'Test1=I got it!' -A 'Test2=Another action'"
     )
+)
+
+create_bind(
+    "SUPER + Slash",
+    hl.dsp.global("caelestia:cheatsheet"),
+    nil,
+    "Launcher: Open the keybind cheatsheet"
 )

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -146,8 +146,8 @@ create_bind(vars.kbWindowIncreaseWidth, fn.resize_active_window(10, 0), repeatin
 create_bind(vars.kbWindowDecreaseHeight, fn.resize_active_window(0, -10), repeating, "Window Actions: Decrease the active window height")
 create_bind(vars.kbWindowIncreaseHeight, fn.resize_active_window(0, 10), repeating, "Window Actions: Increase the active window height")
 
-create_bind({ vars.kbMoveWindow, "SUPER + mouse:272" }, hl.dsp.window.drag(), mouse, "Window Actions: Drag the active window")
-create_bind({ vars.kbResizeWindow, "SUPER + mouse:273" }, hl.dsp.window.resize(), mouse, "Window Actions: Resize the active window")
+create_bind({ vars.kbMoveWindow, "SUPER + mouse:272" }, hl.dsp.window.drag(), "Window Actions: Move the window by dragging", mouse)
+create_bind({ vars.kbResizeWindow, "SUPER + mouse:273" }, hl.dsp.window.resize(), "Window Actions: Resize the window by dragging", mouse)
 create_bind(vars.kbCenterWindow, hl.dsp.window.center(), "Window Actions: Center the active window")
 create_bind(vars.kbNormalizeWindow, function()
     hl.dispatch(hl.dsp.window.resize(fn.resize_by_screen(55, 70)))

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -230,7 +230,7 @@ create_bind(
 )
 
 -- Sleep
-create_bind(vars.kbSleep, hl.dsp.exec_cmd(vars.sleepGestureCmd), locked, "Sleep: Suspend and hibernate the system")
+create_bind(vars.kbSleep, hl.dsp.exec_cmd(vars.sleepGestureCmd), "Misc: Run the sleep command", locked)
 
 -- Clipboard and emoji picker
 create_bind(vars.kbClipboard, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard"), "Clipboard: Open clipboard history")

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -94,7 +94,7 @@ end,
 )
 
 -- Kill/restart
-create_bind("CTRL + SUPER + SHIFT + R", hl.dsp.exec_cmd("qs -c caelestia kill"), release, "System: Restart the Caelestia shell")
+create_bind("CTRL + SUPER + SHIFT + R", hl.dsp.exec_cmd("qs -c caelestia kill"), "Shell: Kill the running shell", release)
 create_bind(
     "CTRL + SUPER + ALT + R",
     hl.dsp.exec_cmd("qs -c caelestia kill; sleep .1; caelestia shell -d"),

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -105,29 +105,29 @@ for i = 1, 10 do
 end
 
 -- Go to workspace -1/+1
-create_bind(vars.kbPrevWs, hl.dsp.focus({ workspace = "-1" }), "Workspace: Go to the previous workspace", repeating_unless_mouse)
-create_bind(vars.kbNextWs, hl.dsp.focus({ workspace = "+1" }), "Workspace: Go to the next workspace", repeating_unless_mouse)
+create_bind(vars.kbPrevWs, hl.dsp.focus({ workspace = "-1" }), "Workspaces: Go to the previous workspace", repeating_unless_mouse)
+create_bind(vars.kbNextWs, hl.dsp.focus({ workspace = "+1" }), "Workspaces: Go to the next workspace", repeating_unless_mouse)
 
 -- Go to workspace group -1/+1
-create_bind(vars.kbPrevWsGroup, hl.dsp.focus({ workspace = "-10" }), "Workspace: Go to the previous workspace group", repeating_unless_mouse)
-create_bind(vars.kbNextWsGroup, hl.dsp.focus({ workspace = "+10" }), "Workspace: Go to the next workspace group", repeating_unless_mouse)
+create_bind(vars.kbPrevWsGroup, hl.dsp.focus({ workspace = "-10" }), "Workspaces: Go to the previous workspace group", repeating_unless_mouse)
+create_bind(vars.kbNextWsGroup, hl.dsp.focus({ workspace = "+10" }), "Workspaces: Go to the next workspace group", repeating_unless_mouse)
 
 -- Move window to workspace -1/+1
-create_bind(vars.kbMoveWinToWsNext, hl.dsp.window.move({ workspace = "+1" }), "Workspace: Move the active window to the next workspace", repeating_unless_mouse)
-create_bind(vars.kbMoveWinToWsPrev, hl.dsp.window.move({ workspace = "-1" }), "Workspace: Move the active window to the previous workspace", repeating_unless_mouse)
+create_bind(vars.kbMoveWinToWsNext, hl.dsp.window.move({ workspace = "+1" }), "Workspaces: Move the window to the next workspace", repeating_unless_mouse)
+create_bind(vars.kbMoveWinToWsPrev, hl.dsp.window.move({ workspace = "-1" }), "Workspaces: Move the window to the previous workspace", repeating_unless_mouse)
 
 -- Move window to/from special workspace
-create_bind(vars.kbMoveWinToWsSpecial, hl.dsp.window.move({ workspace = "special:special" }), "Workspace: Move the active window to the special workspace")
-create_bind(vars.kbMoveWinFromWsSpecial, hl.dsp.window.move({ workspace = "e+0" }), "Workspace: Move the active window out of the special workspace")
+create_bind(vars.kbMoveWinToWsSpecial, hl.dsp.window.move({ workspace = "special:special" }), "Workspaces: Move the window to the special workspace")
+create_bind(vars.kbMoveWinFromWsSpecial, hl.dsp.window.move({ workspace = "e+0" }), "Workspaces: Move the window out of the special workspace")
 
 -- Window groups
 create_bind(vars.kbWindowCycleNext, hl.dsp.window.cycle_next(), "Window Groups: Cycle to the next window", repeating)
 create_bind(vars.kbWindowCyclePrev, hl.dsp.window.cycle_next({ next = false }), "Window Groups: Cycle to the previous window", repeating)
 create_bind(vars.kbWindowGroupCycleNext, hl.dsp.group.next(), "Window Groups: Cycle to the next window group", repeating)
 create_bind(vars.kbWindowGroupCyclePrev, hl.dsp.group.prev(), "Window Groups: Cycle to the previous window group", repeating)
-create_bind(vars.kbToggleGroup, hl.dsp.group.toggle(), "Window Groups: Toggle the active window group")
-create_bind(vars.kbUngroup, hl.dsp.window.move({ out_of_group = true }), "Window Groups: Remove the active window from its group")
-create_bind(vars.kbGroupLockActive, hl.dsp.group.lock_active(), "Window Groups: Lock the active window group")
+create_bind(vars.kbToggleGroup, hl.dsp.group.toggle(), "Window Groups: Toggle the window group")
+create_bind(vars.kbUngroup, hl.dsp.window.move({ out_of_group = true }), "Window Groups: Remove the window from its group")
+create_bind(vars.kbGroupLockActive, hl.dsp.group.lock_active(), "Window Groups: Lock the window group")
 
 -- Window actions
 for _, dir in ipairs({ "left", "right", "up", "down" }) do
@@ -135,19 +135,19 @@ for _, dir in ipairs({ "left", "right", "up", "down" }) do
     create_bind("SUPER + SHIFT + " .. dir, hl.dsp.window.move({ direction = dir }), "Window Actions: Move the window to the " .. dir)
 end
 
-create_bind(vars.kbWindowDecreaseWidth, fn.resize_active_window(-10, 0), "Window Actions: Decrease the active window width", repeating)
-create_bind(vars.kbWindowIncreaseWidth, fn.resize_active_window(10, 0), "Window Actions: Increase the active window width", repeating)
-create_bind(vars.kbWindowDecreaseHeight, fn.resize_active_window(0, -10), "Window Actions: Decrease the active window height", repeating)
-create_bind(vars.kbWindowIncreaseHeight, fn.resize_active_window(0, 10), "Window Actions: Increase the active window height", repeating)
+create_bind(vars.kbWindowDecreaseWidth, fn.resize_active_window(-10, 0), "Window Actions: Decrease the window width", repeating)
+create_bind(vars.kbWindowIncreaseWidth, fn.resize_active_window(10, 0), "Window Actions: Increase the window width", repeating)
+create_bind(vars.kbWindowDecreaseHeight, fn.resize_active_window(0, -10), "Window Actions: Decrease the window height", repeating)
+create_bind(vars.kbWindowIncreaseHeight, fn.resize_active_window(0, 10), "Window Actions: Increase the window height", repeating)
 
 create_bind({ vars.kbMoveWindow, "SUPER + mouse:272" }, hl.dsp.window.drag(), "Window Actions: Move the window by dragging", mouse)
 create_bind({ vars.kbResizeWindow, "SUPER + mouse:273" }, hl.dsp.window.resize(), "Window Actions: Resize the window by dragging", mouse)
-create_bind(vars.kbCenterWindow, hl.dsp.window.center(), "Window Actions: Center the active window")
+create_bind(vars.kbCenterWindow, hl.dsp.window.center(), "Window Actions: Center the window")
 create_bind(vars.kbNormalizeWindow, function()
     hl.dispatch(hl.dsp.window.resize(fn.resize_by_screen(55, 70)))
     hl.dispatch(hl.dsp.window.center())
 end,
-    "Window Actions: Resize and center the active window"
+    "Window Actions: Resize and center the window"
 )
 create_bind(vars.kbWindowPip, function()
     local a = hl.get_active_window()
@@ -163,11 +163,11 @@ create_bind(vars.kbWindowPip, function()
 end,
     "Window Actions: Toggle picture-in-picture mode"
 )
-create_bind(vars.kbPinWindow, hl.dsp.window.pin(), "Window Actions: Pin the active window")
+create_bind(vars.kbPinWindow, hl.dsp.window.pin(), "Window Actions: Pin the window")
 create_bind(vars.kbWindowFullscreen, hl.dsp.window.fullscreen({ mode = "fullscreen" }), "Window Actions: Toggle fullscreen mode")
 create_bind(vars.kbWindowBorderedFullscreen, hl.dsp.window.fullscreen({ mode = "maximized" }), "Window Actions: Toggle bordered fullscreen mode")
 create_bind(vars.kbToggleWindowFloating, hl.dsp.window.float(), "Window Actions: Toggle floating mode")
-create_bind(vars.kbCloseWindow, hl.dsp.window.close(), "Window Actions: Close the active window")
+create_bind(vars.kbCloseWindow, hl.dsp.window.close(), "Window Actions: Close the window")
 
 -- Special workspace toggles
 create_bind(vars.kbSpecialWs, fn.toggle("specialws"), "Special Workspaces: Toggle the special workspace")

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -99,7 +99,7 @@ create_bind(
     "CTRL + SUPER + ALT + R",
     hl.dsp.exec_cmd("qs -c caelestia kill; sleep .1; caelestia shell -d"),
     release,
-    "System: Restart the Caelestia shell and reload it cleanly"
+    "Shell: Restart the shell"
 )
 
 for i = 1, 10 do

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -254,8 +254,7 @@ create_bind(
 )
 
 create_bind(
-    "SUPER + Slash",
+    vars.kbCheatsheet,
     hl.dsp.global("caelestia:cheatsheet"),
-    nil,
-    "Launcher: Open the keybind cheatsheet"
+    "Shell: Open the keybind cheatsheet"
 )

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -203,10 +203,10 @@ create_bind("XF86MonBrightnessUp", hl.dsp.global("caelestia:brightnessUp"), lock
 create_bind("XF86MonBrightnessDown", hl.dsp.global("caelestia:brightnessDown"), locked, "Brightness: Decrease screen brightness")
 
 -- Media
-create_bind({ vars.kbMediaToggle, "XF86AudioPlay", "XF86AudioPause" }, hl.dsp.global("caelestia:mediaToggle"), locked, "Media: Play or pause media")
-create_bind({ vars.kbMediaNext, "XF86AudioNext" }, hl.dsp.global("caelestia:mediaNext"), locked, "Media: Skip to the next track")
-create_bind({ vars.kbMediaPrev, "XF86AudioPrev" }, hl.dsp.global("caelestia:mediaPrev"), locked, "Media: Go to the previous track")
-create_bind({ vars.kbMediaStop, "XF86AudioStop" }, hl.dsp.global("caelestia:mediaStop"), locked, "Media: Stop media playback")
+create_bind({ vars.kbMediaToggle, "XF86AudioPlay", "XF86AudioPause" }, hl.dsp.global("caelestia:mediaToggle"), "Media: Toggle playback", locked)
+create_bind({ vars.kbMediaNext, "XF86AudioNext" }, hl.dsp.global("caelestia:mediaNext"), "Media: Skip to the next track", locked)
+create_bind({ vars.kbMediaPrev, "XF86AudioPrev" }, hl.dsp.global("caelestia:mediaPrev"), "Media: Go to the previous track", locked)
+create_bind({ vars.kbMediaStop, "XF86AudioStop" }, hl.dsp.global("caelestia:mediaStop"), "Media: Stop playback", locked)
 
 -- Volume
 create_bind({ vars.kbVolumeMute, "XF86AudioMute" }, hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), locked, "Volume: Toggle system audio mute")

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -137,8 +137,8 @@ create_bind(vars.kbGroupLockActive, hl.dsp.group.lock_active(), "Window Groups: 
 
 -- Window actions
 for _, dir in ipairs({ "left", "right", "up", "down" }) do
-    create_bind("SUPER + " .. dir, hl.dsp.focus({ direction = dir }), "Window Actions: Focus the window in the specified direction")
-    create_bind("SUPER + SHIFT + " .. dir, hl.dsp.window.move({ direction = dir }), "Window Actions: Move the active window in the specified direction")
+    create_bind("SUPER + " .. dir, hl.dsp.focus({ direction = dir }), "Window Actions: Focus the window to the " .. dir)
+    create_bind("SUPER + SHIFT + " .. dir, hl.dsp.window.move({ direction = dir }), "Window Actions: Move the window to the " .. dir)
 end
 
 create_bind(vars.kbWindowDecreaseWidth, fn.resize_active_window(-10, 0), repeating, "Window Actions: Decrease the active window width")

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -171,7 +171,7 @@ end,
 )
 create_bind(vars.kbPinWindow, hl.dsp.window.pin(), "Window Actions: Pin the active window")
 create_bind(vars.kbWindowFullscreen, hl.dsp.window.fullscreen({ mode = "fullscreen" }), "Window Actions: Toggle fullscreen mode")
-create_bind(vars.kbWindowBorderedFullscreen, hl.dsp.window.fullscreen({ mode = "maximized" }), "Window Actions: Toggle maximized mode")
+create_bind(vars.kbWindowBorderedFullscreen, hl.dsp.window.fullscreen({ mode = "maximized" }), "Window Actions: Toggle bordered fullscreen mode")
 create_bind(vars.kbToggleWindowFloating, hl.dsp.window.float(), "Window Actions: Toggle floating mode")
 create_bind(vars.kbCloseWindow, hl.dsp.window.close(), "Window Actions: Close the active window")
 

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -83,7 +83,7 @@ create_bind(vars.kbSession, hl.dsp.global("caelestia:session"), "Shell: Open the
 create_bind(vars.kbShowSidebar, hl.dsp.global("caelestia:sidebar"), "Shell: Show the sidebar")
 create_bind(vars.kbClearNotifs, hl.dsp.global("caelestia:clearNotifs"), "Shell: Clear all notifications", locked)
 create_bind(vars.kbShowPanels, hl.dsp.global("caelestia:showall"), "Shell: Show all panels")
-create_bind(vars.kbLock, hl.dsp.global("caelestia:lock"), "Misc: Lock the session")
+create_bind(vars.kbLock, hl.dsp.global("caelestia:lock"), "Shell: Lock the screen")
 
 -- Restore lock
 create_bind(vars.kbRestoreLock, function()

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -185,7 +185,7 @@ create_bind(vars.kbTodoWs, fn.toggle("todo"), "Special Workspaces: Toggle the to
 -- Apps
 create_bind(vars.kbTerminal, hl.dsp.exec_cmd(vars.terminal), "Apps: Open the terminal")
 create_bind(vars.kbBrowser, hl.dsp.exec_cmd(vars.browser), "Apps: Open the web browser")
-create_bind(vars.kbEditor, hl.dsp.exec_cmd(vars.editor), "Apps: Open the code editor")
+create_bind(vars.kbEditor, hl.dsp.exec_cmd(vars.editor), "Apps: Open the editor")
 create_bind(vars.kbFileExplorer, hl.dsp.exec_cmd(vars.fileExplorer), "Apps: Open the file explorer")
 create_bind(vars.kbAudioSettings, hl.dsp.exec_cmd(vars.audioSettings), "Apps: Open the audio settings")
 

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -104,10 +104,10 @@ create_bind(
 
 for i = 1, 10 do
     local key = i % 10 -- 10 maps to key 0
-    create_bind(extend_keybind(vars.kbGoToWs, key), fn.wsaction("focus", "", i), "Workspace: Go to the selected workspace")
-    create_bind(extend_keybind(vars.kbMoveWinToWs, key), fn.wsaction("move", "", i), "Workspace: Move the active window to the selected workspace")
-    create_bind(extend_keybind(vars.kbGoToWsGroup, key), fn.wsaction("focus", "group", i), "Workspace: Go to the selected workspace group")
-    create_bind(extend_keybind(vars.kbMoveWinToWsGroup, key), fn.wsaction("move", "group", i), "Workspace: Move the active window to the selected workspace group")
+    create_bind(extend_keybind(vars.kbGoToWs, key), fn.wsaction("focus", "", i), "Workspaces: Go to workspace " .. i)
+    create_bind(extend_keybind(vars.kbMoveWinToWs, key), fn.wsaction("move", "", i), "Workspaces: Move the window to workspace " .. i)
+    create_bind(extend_keybind(vars.kbGoToWsGroup, key), fn.wsaction("focus", "group", i), "Workspaces: Go to workspace group " .. i)
+    create_bind(extend_keybind(vars.kbMoveWinToWsGroup, key), fn.wsaction("move", "group", i), "Workspaces: Move the window to workspace group " .. i)
 end
 
 -- Go to workspace -1/+1

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -79,10 +79,10 @@ create_bind(
 )
 
 -- Misc
-create_bind(vars.kbSession, hl.dsp.global("caelestia:session"), "Misc: Open the session controls")
-create_bind(vars.kbShowSidebar, hl.dsp.global("caelestia:sidebar"), "Misc: Show the sidebar")
-create_bind(vars.kbClearNotifs, hl.dsp.global("caelestia:clearNotifs"), locked, "Misc: Clear all notifications")
-create_bind(vars.kbShowPanels, hl.dsp.global("caelestia:showall"), "Misc: Show all panels")
+create_bind(vars.kbSession, hl.dsp.global("caelestia:session"), "Shell: Open the session controls")
+create_bind(vars.kbShowSidebar, hl.dsp.global("caelestia:sidebar"), "Shell: Show the sidebar")
+create_bind(vars.kbClearNotifs, hl.dsp.global("caelestia:clearNotifs"), "Shell: Clear all notifications", locked)
+create_bind(vars.kbShowPanels, hl.dsp.global("caelestia:showall"), "Shell: Show all panels")
 create_bind(vars.kbLock, hl.dsp.global("caelestia:lock"), "Misc: Lock the session")
 
 -- Restore lock

--- a/hypr/variables.lua
+++ b/hypr/variables.lua
@@ -141,6 +141,7 @@ return {
     kbLock                     = "SUPER + L",
     kbRestoreLock              = "SUPER + ALT + L",
     kbSleep                    = "SUPER + SHIFT + L",
+    kbCheatsheet               = "SUPER + Slash",
 
     -- Clipboard and emoji picker
     kbClipboard                = "SUPER + V",


### PR DESCRIPTION
Adds categories and descriptions to all Hyprland keybinds for display in the cheatsheet in the format "Category: Description".
Required for cheatsheet (PR caelestia-dots/shell#1868)